### PR TITLE
fix:#145: edit name validator in formsender

### DIFF
--- a/form_sender/validators.py
+++ b/form_sender/validators.py
@@ -22,7 +22,11 @@ def validate_phone_number(value):
 
 def validate_name_characters(value):
     """Валидация имени."""
-    pattern = r'^[a-zA-Zа-яА-я]+$'
-    if not re.match(pattern, value):
-        raise serializers.ValidationError('Имя должно состоять из букв')
+    pattern = re.compile(r'^[a-zA-Zа-яА-Я0-9 _\-\(\)\.,`]+$')
+    if not pattern.fullmatch(value):
+        raise serializers.ValidationError(
+            'Имя может содержать только буквы (латиница, кириллица), '
+            'цифры, пробел, подчёркивание, дефис, скобки, точку, '
+            'запятую и апостроф.'
+        )
     return value


### PR DESCRIPTION
Изменён валидатор. Теперь имя может содержать только буквы (латиница, кириллица), цифры, пробел, подчёркивание, дефис, скобки, точку, запятую и апостроф.